### PR TITLE
Correction de l'état de Bell avec la notation verticale.

### DIFF
--- a/decouverte/decouverte.tex
+++ b/decouverte/decouverte.tex
@@ -1151,7 +1151,7 @@ $$\begin{array}{c}\ket0\\\otimes\\\ket0\end{array} \qquad
 }
 \qquad
 \frac1{\sqrt2}\begin{array}{c}\ket0\\\otimes\\\ket0\end{array}
-+ \frac1{\sqrt2}\begin{array}{c}\ket1\\\otimes\\\ket0\end{array}
++ \frac1{\sqrt2}\begin{array}{c}\ket1\\\otimes\\\ket1\end{array}
 = \ket{\Phi^+}
 $$
 


### PR DESCRIPTION
Bonjour,

Dans la mise en forme verticale, le deuxième élément de l'état de Bell est écrit `|1.0>` au lieu de la valeur correcte `|1.1>` qu'on retrouve dans la forme horizontale au dessus.

Il y avait la même erreur lors de la présentation de cet état à la page 15 du livre papier, elle a visiblement déjà été corrigée.